### PR TITLE
Extract skip touch behaviour out of LicenseValidationService

### DIFF
--- a/app/services/license_validation_service.rb
+++ b/app/services/license_validation_service.rb
@@ -2,19 +2,16 @@
 
 class LicenseValidationService < BaseService
 
-  def initialize(license:, scope: nil, skip_touch: false)
+  def initialize(license:, scope: nil)
     @account    = license&.account
     @product    = license&.product
     @license    = license
     @scope      = scope
-    @skip_touch = skip_touch
     self.license.set_last_validated_attributes(last_validated_at: Time.current)
   end
 
   def call
-    res = validate!
-    touch! unless skip_touch?
-    res
+    validate!
   end
 
   private
@@ -23,8 +20,6 @@ class LicenseValidationService < BaseService
               :product,
               :license,
               :scope
-
-  def skip_touch? = !!@skip_touch
 
   def validate!
     return [false, "does not exist", :NOT_FOUND] if license.nil?
@@ -411,11 +406,5 @@ class LicenseValidationService < BaseService
 
     # All good
     return [true, "is valid", :VALID]
-  end
-
-  def touch!
-    return if skip_touch? || license.nil?
-
-    license.persist_last_validated_attributes!
   end
 end


### PR DESCRIPTION
Hi Keygen :wave:

Last summer you responded to [a tweet that I wrote](https://x.com/keygen_sh/status/1797727382264250509), offering to refactor service objects into oblivion.

I have prepared some PRs that (I hope) will make the `LicenseValidationService` (your pet dragon) a lot easier to maintain.

---

- [PR 1: Extract touches from the service](https://github.com/Bodacious/keygen-api/pull/2)
- [PR 2: Extract skip decision from the service](https://github.com/Bodacious/keygen-api/pull/3)  <= you are here
- [PR 3: Extract each license check into own class](https://github.com/Bodacious/keygen-api/pull/4) 

This PR extracts the decision to skip the validation or not out of the `LicenseValidationService` and into the controller that consumes it. This controller is already responsible for this knowledge, and it seems to be used to check whether side effects should be persisted or not—that seemed out of scope from the validation itself. 